### PR TITLE
Added option to load custom bootloader and application code

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -560,7 +560,9 @@ void MainWindow::startProcess(const QStringList& args)
 
 bool MainWindow::getElfSections(const QString &fileName, QStringList &sections)
 {
+    //FIXME: this is not working for AVR elf files
     QFile file(fileName);
+
     if (!file.open(QFile::ReadOnly))
     {
         qDebug()<<file.errorString();
@@ -570,6 +572,7 @@ bool MainWindow::getElfSections(const QString &fileName, QStringList &sections)
     QByteArray ba;
     ba.resize(0x3E);
     qint64 len = file.read(ba.data(), 0x34);
+
     if (len < 0)
     {
         qDebug()<<file.errorString();
@@ -590,7 +593,7 @@ bool MainWindow::getElfSections(const QString &fileName, QStringList &sections)
         return false;
     }
 
-    int stringTableSize = 0;
+    int stringTableSize   = 0;
     int stringTableOffset = 0;
     for (int offset = 0; offset < sectionTableSize; offset += sizeOfSection)
     {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -33,10 +33,11 @@ private slots:
     void on_processFinished(int exitCode);
     void on_flashBrowse_clicked();
     void on_eepromBrowse_clicked();
-    void on_pfileBrowse_clicked();
-    void on_pfileEdit_editingFinished();
+    void on_pfileEdit_editingFinished(const QString& filePath);
     void on_startButton_clicked();
     void on_showDebug_toggled(bool checked);
+    void on_pAppBrowse_clicked();
+    void on_pBootBrowse_clicked();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -199,17 +199,79 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="plockDevice">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Lock Device</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>
-         <widget class="QLineEdit" name="pfileEdit"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pfileBrowse">
-          <property name="text">
-           <string>Browse</string>
-          </property>
-         </widget>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QFrame" name="horizontalFrame_2">
+            <layout class="QHBoxLayout" name="horizontalLayout_7">
+             <item>
+              <widget class="QLabel" name="labelBootCode">
+               <property name="text">
+                <string>Bootloader</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="pBootEdit"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pBootBrowse">
+               <property name="text">
+                <string>Browse</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QFrame" name="horizontalFrame">
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="labelApp">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Application</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="pAppEdit"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="pAppBrowse">
+               <property name="text">
+                <string>Browse</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
@@ -229,7 +291,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -356,7 +417,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>
@@ -398,7 +458,6 @@
           <property name="font">
            <font>
             <pointsize>8</pointsize>
-            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>


### PR DESCRIPTION
Hi friend,

I found your code while searching for a better way to mass program a device that I have been working on that uses the new CPU AVR128DB48.

In my case I need to load a custom bootloader and the aplication code, but the bootloader will lock the device, thats why I need to load them separatly, it was easier this way instead of trying to merge the elf files.

Any way I tried not to change a lot your code, but while implementing the changes I found some issues:
- The .elf file decoder does not work for the files created for the AVR128DB48, not an issue for me, just to let you know, this not seems to be an easy fix...
- When I installed your program in my secondary D:/ driver the atbackend wont work, only worked when I installed on the main driver, in my case C:/, the work around that I found for this was to force use the atprogram.exe in the instalation path of the atprogramgui, instead of looking for the atmel studio directory, the only strange thing that happen to me for this to work was that I had to delete the atbackend.exe.

Any way, hope you like what I have done, if not, no problem, I really needed something similar to what you have done, and your work made it really easy, nice job!!

Thanks for your help!

![New_GUI](https://user-images.githubusercontent.com/80527080/211033017-787525ad-7eff-4de5-b98f-46f31d034f1b.png)
